### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+name: Build and Release Extension
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Archive extension
+        run: |
+          zip -r extension.zip . -x '*.git*' '.github/*'
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: extension.zip
+


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to zip the extension and publish it as a release when a tag starting with `v` is pushed

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686a7de6f88083228e85ed8a1ee0f47e